### PR TITLE
Set objectName of decoration

### DIFF
--- a/libappletdecoration/previewshareddecoration.cpp
+++ b/libappletdecoration/previewshareddecoration.cpp
@@ -112,6 +112,7 @@ void SharedDecoration::createDecoration()
     if (m_decoration) {
         m_decoration->setSettings(m_settings->settings());
         m_decoration->init();
+        m_decoration->setObjectName("applet-window-buttons");
     }
 
     emit decorationChanged();


### PR DESCRIPTION
In order to make SierraBreezeEnhanced works correctly with this patch: https://github.com/kupiqu/SierraBreezeEnhanced/pull/58

Fix #64 