### PR TITLE
Fix for KDE Plasma 5.18

### DIFF
--- a/libappletdecoration/decorationpalette.cpp
+++ b/libappletdecoration/decorationpalette.cpp
@@ -136,7 +136,7 @@ void DecorationPalette::update()
     m_activeTitleBarColor     = wmConfig.readEntry("activeBackground", m_palette.color(QPalette::Active, QPalette::Highlight));
     m_inactiveTitleBarColor   = wmConfig.readEntry("inactiveBackground", m_inactiveFrameColor);
     m_activeForegroundColor   = wmConfig.readEntry("activeForeground", m_palette.color(QPalette::Active, QPalette::HighlightedText));
-    m_inactiveForegroundColor = wmConfig.readEntry("inactiveForeground", m_activeForegroundColor.dark());
+    m_inactiveForegroundColor = wmConfig.readEntry("inactiveForeground", m_activeForegroundColor.darker());
 
     KConfigGroup windowColorsConfig(config, QStringLiteral("Colors:Window"));
     m_warningForegroundColor = windowColorsConfig.readEntry("ForegroundNegative", QColor(237, 21, 2));

--- a/libappletdecoration/decorationpalette.cpp
+++ b/libappletdecoration/decorationpalette.cpp
@@ -136,7 +136,12 @@ void DecorationPalette::update()
     m_activeTitleBarColor     = wmConfig.readEntry("activeBackground", m_palette.color(QPalette::Active, QPalette::Highlight));
     m_inactiveTitleBarColor   = wmConfig.readEntry("inactiveBackground", m_inactiveFrameColor);
     m_activeForegroundColor   = wmConfig.readEntry("activeForeground", m_palette.color(QPalette::Active, QPalette::HighlightedText));
+
+#if QT_VERSION >= QT_VERSION_CHECK(5,13,0)
     m_inactiveForegroundColor = wmConfig.readEntry("inactiveForeground", m_activeForegroundColor.darker());
+#else
+    m_inactiveForegroundColor = wmConfig.readEntry("inactiveForeground", m_activeForegroundColor.dark());
+#endif
 
     KConfigGroup windowColorsConfig(config, QStringLiteral("Colors:Window"));
     m_warningForegroundColor = windowColorsConfig.readEntry("ForegroundNegative", QColor(237, 21, 2));

--- a/libappletdecoration/previewclient.cpp
+++ b/libappletdecoration/previewclient.cpp
@@ -139,11 +139,6 @@ int PreviewClient::height() const
     return m_height;
 }
 
-QSize PreviewClient::size() const
-{
-    return {m_width, m_height};
-}
-
 QString PreviewClient::caption() const
 {
     return m_caption;
@@ -401,6 +396,12 @@ void PreviewClient::requestHideToolTip()
 }
 #endif
 
+#if KDECORATION2_VERSION_MINOR >= 18
+QSize PreviewClient::size() const
+{
+    return {m_width, m_height};
+}
+#endif
 
 void PreviewClient::requestClose()
 {

--- a/libappletdecoration/previewclient.cpp
+++ b/libappletdecoration/previewclient.cpp
@@ -139,6 +139,11 @@ int PreviewClient::height() const
     return m_height;
 }
 
+QSize PreviewClient::size() const
+{
+    return {m_width, m_height};
+}
+
 QString PreviewClient::caption() const
 {
     return m_caption;

--- a/libappletdecoration/previewclient.h
+++ b/libappletdecoration/previewclient.h
@@ -95,7 +95,6 @@ public:
 
     int width() const override;
     int height() const override;
-    QSize size() const override;
     QPalette palette() const override;
     QColor color(KDecoration2::ColorGroup group, KDecoration2::ColorRole role) const override;
     Qt::Edges adjacentScreenEdges() const override;
@@ -106,6 +105,10 @@ public:
 #if KDECORATION2_VERSION_MINOR >= 13
     void requestShowToolTip(const QString &text) override;
     void requestHideToolTip() override;
+#endif
+
+#if KDECORATION2_VERSION_MINOR >= 18
+    QSize size() const override;
 #endif
 
     void requestClose() override;

--- a/libappletdecoration/previewclient.h
+++ b/libappletdecoration/previewclient.h
@@ -95,6 +95,7 @@ public:
 
     int width() const override;
     int height() const override;
+    QSize size() const override;
     QPalette palette() const override;
     QColor color(KDecoration2::ColorGroup group, KDecoration2::ColorRole role) const override;
     Qt::Edges adjacentScreenEdges() const override;


### PR DESCRIPTION
As noted in issues #81 and #80 this applet stopped working when updating to KDE Plasma 5.18 as some dependencies were updated too.

This PR does the following changes:

- Update a deprecated method usage to use the new recommended method (`dark` -> `darker`)
- Add a missing implementation to a new virtual method from a class the `PreviewClient` class inherits from. (`KDecoration2::ApplicationMenuEnabledDecoratedClientPrivate` which inherits from `KDecoration2::DecoratedClientPrivate` which has the `size()` method marked as virtual)

Applying those fixes allows the project to build and the applet works as expected.

I am running a default installation of KDE Neon 5.18 with the stock Breeze Theme. The applet is added to a Latte-dock panel.

Please do not install from my fork as if this PR is merged I might delete it.

@psifidotos there are many years since I last touched any C++ code and I never worked with Qt/QML before. I guided my fixes from the errors messages when trying to build and used the CLion IDE to help finding the dependencies. If there are any changes you want me to make to this PR, I'll be glad to help.