### PR TITLE
Improve installer, fix deprecations and warnings

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2,6 +2,6 @@ if ! [ -a build ] ; then
     mkdir build
 fi
 cd build
-cmake -DCMAKE_INSTALL_PREFIX=/usr .. -Wnodev
-make
+cmake -DCMAKE_INSTALL_PREFIX=/usr -DCMAKE_BUILD_TYPE=Release -Wnodev ..
+make -j$(nproc)
 sudo make install

--- a/libappletdecoration/appletdecorationplugin.cpp
+++ b/libappletdecoration/appletdecorationplugin.cpp
@@ -57,10 +57,17 @@ void AppletDecorationPlugin::registerTypes(const char *uri)
     qmlRegisterType<Decoration::Applet::ExtendedTheme>(uri, 0, 1, "PlasmaThemeExtended");
     qmlRegisterType<Decoration::Applet::WindowSystem>(uri, 0, 1, "WindowSystem");
 
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 14, 0))
+    qmlRegisterAnonymousType<Decoration::Applet::Padding>("", 1);
+    qmlRegisterAnonymousType<Decoration::Applet::PreviewClient>("", 1);
+    qmlRegisterAnonymousType<Decoration::Applet::PreviewBridge>("", 1);
+    qmlRegisterAnonymousType<KDecoration2::Decoration>("", 1);
+#else
     qmlRegisterType<Decoration::Applet::Padding>();
     qmlRegisterType<Decoration::Applet::PreviewClient>();
     qmlRegisterType<Decoration::Applet::PreviewBridge>();
     qmlRegisterType<KDecoration2::Decoration>();
+#endif
 
     qmlRegisterSingletonType<Decoration::Applet::Environment>(uri, 0, 1, "Environment", &Decoration::Applet::Environment::instance);
 }

--- a/libappletdecoration/previewclient.cpp
+++ b/libappletdecoration/previewclient.cpp
@@ -387,6 +387,7 @@ void PreviewClient::setBordersTopEdge(bool enabled)
 #if KDECORATION2_VERSION_MINOR >= 13
 void PreviewClient::requestShowToolTip(const QString &text)
 {
+    Q_UNUSED(text)
     //qDebug() << "tooltip show requested with text:" << text;
 }
 


### PR DESCRIPTION
When compiling the project the installer uses all available cores and the build type is now set to Release.

Additionally the unused warning and the deprecation warnings for qt >= 5.14 have been fixed.