### PR TITLE
Support building on plasma 5.26.90+

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ set(EMAIL "mvourlakos@gmail.com")
 
 set(QT_MIN_VERSION "5.15.0")
 set(KF5_MIN_VERSION "5.81.0")
-set(KDECORATION2_MIN_VERSION "5.24.0")
+set(KDECORATION2_MIN_VERSION "5.26.90")
 
 set(KF5_LOCALE_PREFIX "")
 

--- a/libappletdecoration/previewclient.cpp
+++ b/libappletdecoration/previewclient.cpp
@@ -263,6 +263,11 @@ WId PreviewClient::windowId() const
     return 0;
 }
 
+QString PreviewClient::windowClass() const
+{
+    return QString("kwin_preview");
+}
+
 QPalette PreviewClient::palette() const
 {
     return m_palette->palette();

--- a/libappletdecoration/previewclient.h
+++ b/libappletdecoration/previewclient.h
@@ -74,6 +74,7 @@ public:
     QString caption() const override;
     WId decorationId() const override;
     WId windowId() const override;
+    QString windowClass() const override;
     int desktop() const override;
     QIcon icon() const override;
     bool isActive() const override;


### PR DESCRIPTION
Fixes https://github.com/psifidotos/applet-window-buttons/issues/190 in a naive way. 

After changes in libkdecoration private api the applet's libdecoration should implement `PreviewClient::windowClass()` method. 

Instead of getting window_class of the real window the code returns placeholder values like in `windowId()` and `decorationId()` methods.